### PR TITLE
test(use-long-press): Restore 100% tests coverage

### DIFF
--- a/packages/use-long-press/src/lib/tests/pointer-event.polyfill.ts
+++ b/packages/use-long-press/src/lib/tests/pointer-event.polyfill.ts
@@ -22,6 +22,7 @@ export class PointerEvent extends MouseEvent {
     this.pointerType = params.pointerType;
     this.isPrimary = params.isPrimary;
   }
+  /* c8 ignore next 1 */
 }
 
 if (!global.PointerEvent) {

--- a/packages/use-long-press/src/lib/tests/use-long-press.test.tsx
+++ b/packages/use-long-press/src/lib/tests/use-long-press.test.tsx
@@ -195,7 +195,7 @@ describe('Detecting long press', () => {
     // Use fake timers for detecting long press
     vi.useFakeTimers();
 
-    threshold = Math.round(Math.random() * 1000);
+    threshold = Math.round(500 + Math.random() * 500);
 
     callback = vi.fn();
     onStart = vi.fn();
@@ -638,7 +638,7 @@ describe('Hook context', () => {
     // Use fake timers for detecting long press
     vi.useFakeTimers();
     // Setup common variables
-    threshold = Math.round(Math.random() * 1000);
+    threshold = Math.round(500 + Math.random() * 500);
     callback = vi.fn();
     onStart = vi.fn();
     onMove = vi.fn();

--- a/packages/use-long-press/src/lib/tests/use-long-press.test.tsx
+++ b/packages/use-long-press/src/lib/tests/use-long-press.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react-hooks";
-import { fireEvent, render } from "@testing-library/react";
+import { createEvent, fireEvent, render } from "@testing-library/react";
 import { useLongPress } from "../use-long-press";
 import {
   LongPressCallback,
@@ -33,9 +33,13 @@ import {
   createMockedPointerEvent,
   createMockedTouchEvent,
   createPositionedDomEventFactory,
+  createPositionedMouseEvent,
+  createPositionedPointerEvent,
+  createPositionedTouchEvent,
   getDOMTestHandlersMap,
   getTestHandlersMap
 } from "./use-long-press.test.utils";
+import { isMouseEvent, isPointerEvent, isTouchEvent } from "../use-long-press.utils";
 
 /*
  ⌜‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
@@ -1121,4 +1125,81 @@ describe('Hook usability', () => {
       expect(onFinish).toHaveBeenCalledTimes(0);
     }
   );
+});
+
+describe('Utils', () => {
+  test.each([
+    [{ nativeEvent: new MouseEvent('mousedown') }, true],
+    [{ nativeEvent: new MouseEvent('mousemove') }, true],
+    [{ nativeEvent: new MouseEvent('mouseup') }, true],
+
+    [createMockedMouseEvent(), true],
+    [createMockedTouchEvent(), false],
+    [createMockedPointerEvent(), false],
+
+    [{ nativeEvent: createPositionedMouseEvent(window, 'mouseMove', 1, 2) }, true],
+    [{ nativeEvent: createPositionedTouchEvent(window, 'touchMove', 1, 2) }, false],
+    [{ nativeEvent: createPositionedPointerEvent(window, 'pointerMove', 1, 2) }, false],
+
+    [{ nativeEvent: new MouseEvent('mousedown') }, true],
+    [{ nativeEvent: new TouchEvent('touchstart') }, false],
+    [{ nativeEvent: new PointerEvent('pointerdown') }, false],
+    [{ nativeEvent: new Event('blur') }, false],
+
+    [{ nativeEvent: createEvent.mouseUp(window) }, true],
+    [{ nativeEvent: createEvent.touchEnd(window) }, false],
+    [{ nativeEvent: createEvent.pointerUp(window) }, false],
+  ])('isMouseEvent treat %s as mouse event: %s', (event, isProperEvent) => {
+    expect(isMouseEvent(event as LongPressReactEvents)).toBe(isProperEvent);
+  });
+
+  test.each([
+    [{ nativeEvent: new TouchEvent('touchstart') }, true],
+    [{ nativeEvent: new TouchEvent('touchmove') }, true],
+    [{ nativeEvent: new TouchEvent('touchend') }, true],
+
+    [createMockedMouseEvent(), false],
+    [createMockedTouchEvent(), true],
+    [createMockedPointerEvent(), false],
+
+    [{ nativeEvent: createPositionedMouseEvent(window, 'mouseMove', 1, 2) }, false],
+    [{ nativeEvent: createPositionedTouchEvent(window, 'touchMove', 1, 2) }, true],
+    [{ nativeEvent: createPositionedPointerEvent(window, 'pointerMove', 1, 2) }, false],
+
+    [{ nativeEvent: new MouseEvent('mousedown') }, false],
+    [{ nativeEvent: new TouchEvent('touchstart') }, true],
+    [{ nativeEvent: new PointerEvent('pointerdown') }, false],
+    [{ nativeEvent: new Event('blur') }, false],
+
+    [{ nativeEvent: createEvent.mouseUp(window) }, false],
+    [{ nativeEvent: createEvent.touchEnd(window) }, true],
+    [{ nativeEvent: createEvent.pointerUp(window) }, false],
+  ])('isTouchEvent treat %s as touch event: %s', (event, isProperEvent) => {
+    expect(isTouchEvent(event as LongPressReactEvents)).toBe(isProperEvent);
+  });
+
+  test.each([
+    [{ nativeEvent: new PointerEvent('pointerdown') }, true],
+    [{ nativeEvent: new PointerEvent('pointermove') }, true],
+    [{ nativeEvent: new PointerEvent('pointerup') }, true],
+
+    [createMockedMouseEvent(), false],
+    [createMockedTouchEvent(), false],
+    [createMockedPointerEvent(), true],
+
+    [{ nativeEvent: createPositionedMouseEvent(window, 'mouseMove', 1, 2) }, false],
+    [{ nativeEvent: createPositionedTouchEvent(window, 'touchMove', 1, 2) }, false],
+    [{ nativeEvent: createPositionedPointerEvent(window, 'pointerMove', 1, 2) }, true],
+
+    [{ nativeEvent: new MouseEvent('mousedown') }, false],
+    [{ nativeEvent: new TouchEvent('touchstart') }, false],
+    [{ nativeEvent: new PointerEvent('pointerdown') }, true],
+    [{ nativeEvent: new Event('blur') }, false],
+
+    [{ nativeEvent: createEvent.mouseUp(window) }, false],
+    [{ nativeEvent: createEvent.touchEnd(window) }, false],
+    [{ nativeEvent: createEvent.pointerUp(window) }, true],
+  ])('isPointerEvent treat %s as pointer event: %s', (event, isProperEvent) => {
+    expect(isPointerEvent(event as LongPressReactEvents)).toBe(isProperEvent);
+  });
 });

--- a/packages/use-long-press/src/lib/tests/use-long-press.test.utils.ts
+++ b/packages/use-long-press/src/lib/tests/use-long-press.test.utils.ts
@@ -59,7 +59,12 @@ export function createMockedDomEventFactory(
  ⎹ Mocked positioned events (with 'x' and 'y' coordinates)
  ⌞____________________________________________________________________________________________________
 */
-export function createPositionedMouseEvent(element: Element, eventType: EventType, x: number, y: number): MouseEvent {
+export function createPositionedMouseEvent(
+  element: Document | Element | Window | Node,
+  eventType: EventType,
+  x: number,
+  y: number
+): MouseEvent {
   const event = createEvent[eventType](element) as unknown as MouseEvent;
   Object.assign(event, {
     pageX: x,
@@ -70,13 +75,14 @@ export function createPositionedMouseEvent(element: Element, eventType: EventTyp
 }
 
 export function createPositionedPointerEvent(
-  element: Element,
+  element: Document | Element | Window | Node,
   eventType: EventType,
   x: number,
   y: number
 ): PointerEvent {
   const event = createEvent[eventType]({
     ...element,
+    // Remove this after jsdom add support for pointer events
     ownerDocument: { ...document, defaultView: window },
   }) as PointerEvent;
   Object.assign(event, {
@@ -87,7 +93,12 @@ export function createPositionedPointerEvent(
   return event;
 }
 
-export function createPositionedTouchEvent(element: Element, eventType: EventType, x: number, y: number): TouchEvent {
+export function createPositionedTouchEvent(
+  element: Document | Element | Window | Node,
+  eventType: EventType,
+  x: number,
+  y: number
+): TouchEvent {
   return createEvent[eventType](element, {
     touches: [{ pageX: x, pageY: y } as Touch],
   }) as TouchEvent;

--- a/packages/use-long-press/src/lib/use-long-press.utils.ts
+++ b/packages/use-long-press/src/lib/use-long-press.utils.ts
@@ -16,7 +16,7 @@ export function isTouchEvent<Target extends Element>(event: SyntheticEvent<Targe
 }
 
 export function isMouseEvent<Target extends Element>(event: SyntheticEvent<Target>): event is ReactMouseEvent<Target> {
-  return event.nativeEvent instanceof MouseEvent;
+  return event.nativeEvent instanceof MouseEvent && !(event.nativeEvent instanceof PointerEvent);
 }
 
 export function isPointerEvent<Target extends Element>(
@@ -49,7 +49,6 @@ export function getCurrentPosition<Target extends Element>(
     };
   }
 
-  /* istanbul ignore else */
   if (isMouseEvent(event) || isPointerEvent(event)) {
     return {
       x: event.pageX,
@@ -57,7 +56,6 @@ export function getCurrentPosition<Target extends Element>(
     };
   }
 
-  /* istanbul ignore next */
   return null;
 }
 


### PR DESCRIPTION
- Add tests covering util functions
- Fix unpredictable tests when randomizing long press threshold