### PR TITLE
package.json should have the types property inside 'exports' field so…

### DIFF
--- a/packages/use-long-press/package.json
+++ b/packages/use-long-press/package.json
@@ -23,7 +23,8 @@
   "exports": {
     ".": {
       "import": "./index.mjs",
-      "require": "./index.js"
+      "require": "./index.js",
+      "types": "./index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
… that TS types can be correctly imported (#18)